### PR TITLE
Fix deprecation warning for json_normalize

### DIFF
--- a/Week_2/Assingment_2.1.ipynb
+++ b/Week_2/Assingment_2.1.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "import pandas as pd\n",
     "import requests\n",
-    "from pandas.io.json import json_normalize"
+    "from pandas import json_normalize"
    ]
   },
   {


### PR DESCRIPTION
The following warning occurred when executing on of the code blocks in Assignment_2_1.ipynb:
> FutureWarning: pandas.io.json.json_normalize is deprecated, use pandas.json_normalize instead

- Change the import as recommended